### PR TITLE
Atualizar documentação do burndown de riscos no ghpages

### DIFF
--- a/docs/metodology/sprints/sprint_13/sprint_13_review.md
+++ b/docs/metodology/sprints/sprint_13/sprint_13_review.md
@@ -1,0 +1,81 @@
+# Review/Retrospectiva [Sprint 13]()
+
+## Status das Histórias
+
+
+
+### Rastreabilidade de impedimentos
+
+
+
+## Retrospectiva  
+
+## Indicadores
+
+### Produtividade
+
+#### Commits/dia
+
+
+### Velocity
+
+### Evolução de Conhecimento
+#### Quadro de Habilidades
+
+
+### Burndown de riscos
+O Burndown de riscos avalia a evolução dos riscos selecionados pela equipe durante o decorrer do projeto. Mais detalhes sobre os riscos selecionados podem ser encontrados no documento de [Riscos](https://github.com/fga-gpp-mds/2018.1-TropicalHazards-BI/blob/master/docs/wiki/riscos.md)
+
+Devido ao acompanhamento do gráfico não ter sido realizado nas outras sprints, as atualizações gerais do burndown de riscos estão refletidas neste documento. O risco 5 foi removido por não estar coerente com o contexto da disciplina, sendo um fator externo que não deveria afetar o desenvolvimento do projeto. Com a arquitetura do projeto definida e o fluxo de DevOps estabelecido, o R04 foi atualizado para refletir um novo risco arquitetural, voltado para a necessidade da coerência das novas funcionalidades implentadas em relação ao padrão arquitetural definido.
+
+<img src="https://i.imgur.com/ylzeUJC.png" class="responsive-img">
+
+<table class="responsive-table highlight bordered">
+    <thead>
+        <tr>
+            <td>Risco</td>
+            <td>Descrição</td>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>R01</th>
+            <td>Projeto não atender os requisitos</td>
+        </tr>
+        <tr>
+            <th>R02</th>
+            <td>Inexperiência com a tecnologia de desenvolvimento</td>
+        </tr>
+        <tr>
+            <th>R03</th>
+            <td>Comunicação falha entre os membros</td>
+        </tr>
+        <tr>
+            <th>R04</th>
+            <td>Equipe de desenvolvimento não seguir a arquitetura</td>
+        </tr>
+        <tr>
+            <th>R06</th>
+            <td>Falta de compromentimento</td>
+        </tr>
+        <tr>
+            <th>R07</th>
+            <td>Baixa Produtividade</td>
+        </tr>
+        <tr>
+            <th>R08</th>
+            <td>Conhecimento desnivelado</td>
+        </tr>
+        <tr>
+            <th>R09</th>
+            <td>Membro abandonar a disciplina</td>
+        </tr>
+        <tr>
+            <th>R10</th>
+            <td>Dificuldade de aprendizado ao trabalhar com tecnologias diferentes ao mesmo tempo</td>
+        </tr>
+    </tbody>
+</table>
+
+
+## Análise do Scrum Master


### PR DESCRIPTION
## Tipo da mudança 
- [X] Atualiza documentação 

## Descrição das mudanças 
Atualiza definição dos riscos e acompanhamento dos gráficos

## Conecte a Issue 
Conecte sua issue abaixo com o GitHub :v:
