### PR TITLE
Corrige tratamento ao receber dimensões vazias

### DIFF
--- a/metabase/views.py
+++ b/metabase/views.py
@@ -88,8 +88,8 @@ class DashboardIframes(APIView):
             },
             "visualization_settings": self.make_visualization_settings(
                                       request.data['display'],
-                                      request.data['dimension'],
-                                      request.data['metric'])
+                                      request.data.get('dimension', ''),
+                                      request.data.get('metric', ''))
 
         }
 


### PR DESCRIPTION
## Tipo da mudança 
- [X] Resolve Bug 
- [ ] Adiciona nova funcionalidade 
- [ ] Atualiza documentação 

## Descrição das mudanças 
Corrigir o tratamento quando receber os parâmetros `dimension` e `metric`vazios ao criar uma question vazia.

## Conecte a Issue 
Conecte sua issue abaixo com o GitHub :v:
