### PR TITLE
Sincroniza metabase com mongo depois de upload

### DIFF
--- a/import_data/tests.py
+++ b/import_data/tests.py
@@ -11,6 +11,7 @@ from rest_framework.test import APIRequestFactory
 from rest_framework.test import force_authenticate
 from rest_framework.exceptions import ValidationError
 from model_mommy import mommy
+from unittest.mock import patch
 
 from TropicalHazards_BI.utils import connect_mongo
 from import_data import views
@@ -74,6 +75,33 @@ def valid_table_headers():
                 "transform": ""}
             ]
     return json.dumps(table_headers)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def mock_metabase_sync_schema():
+    """ Mock return of function sync_schema from metabase.utils module"""
+
+    mock_sync_schema_patch = patch('metabase.utils.sync_schema')
+    mock_sync_schema = mock_sync_schema_patch.start()
+    mock_sync_schema.return_value = True
+
+
+@pytest.fixture(scope="function", autouse=True)
+def mock_metabase_login():
+    """ Mock return of function login_metabase from metabase.utils module"""
+
+    mock_login_patch = patch('metabase.utils.login_metabase')
+    mock_login = mock_login_patch.start()
+    mock_login.return_value = "tokenofmetabase"
+
+
+@pytest.fixture(scope="function", autouse=True)
+def mock_metabase_get_database():
+    """ Mock return of function get_database_id from metabase.utils module"""
+
+    mock_get_db_patch = patch('metabase.utils.get_database_id')
+    mock_get_db_id = mock_get_db_patch.start()
+    mock_get_db_id.return_value = 1
 
 
 def teardown_file():

--- a/import_data/views.py
+++ b/import_data/views.py
@@ -14,6 +14,8 @@ from rest_framework.exceptions import ValidationError
 
 from import_data.serializers import ImportDataSerializer
 from TropicalHazards_BI.utils import connect_mongo
+from metabase.utils import get_database_id
+from metabase.utils import sync_schema
 
 
 @permission_classes((permissions.IsAuthenticatedOrReadOnly,))
@@ -105,6 +107,8 @@ class FileUploadView(APIView):
             json_data = json.loads(dataframe.to_json(orient="records"))
 
             if self.save_on_mongo(json_data, project_id):
+                db_id = get_database_id('mongo')
+                sync_schema(db_id)
                 serializer.save()
                 os.remove(file_path)
 

--- a/import_data/views.py
+++ b/import_data/views.py
@@ -14,8 +14,7 @@ from rest_framework.exceptions import ValidationError
 
 from import_data.serializers import ImportDataSerializer
 from TropicalHazards_BI.utils import connect_mongo
-from metabase.utils import get_database_id
-from metabase.utils import sync_schema
+from metabase import utils
 
 
 @permission_classes((permissions.IsAuthenticatedOrReadOnly,))
@@ -107,8 +106,8 @@ class FileUploadView(APIView):
             json_data = json.loads(dataframe.to_json(orient="records"))
 
             if self.save_on_mongo(json_data, project_id):
-                db_id = get_database_id('mongo')
-                sync_schema(db_id)
+                db_id = utils.get_database_id('mongo')
+                utils.sync_schema(db_id)
                 serializer.save()
                 os.remove(file_path)
 


### PR DESCRIPTION
## Tipo da mudança 
- [X] Resolve Bug 

## Descrição das mudanças 
Sincroniza o metabase com o mongo após importar um arquivo.

## Conecte a Issue 
Conecte sua issue abaixo com o GitHub :v:
